### PR TITLE
Continue the execution from a certain module

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,11 @@ You can configure your project in the root pom.xml, in the section \<plugins\>:
   mvn "-DtargetModules=aModuleToSkip,anotherModuleToSkip" pitmp:run
   ```
 
+* continueFromModule: to run PIT starting from a given project (because continuing an aborted execution with Maven -rf is not working)
+  ```
+          <continueFromModule>aModule</continueFromModule>
+  ```
+
 ## Running Descartes
 
 If you want to run Descartes:

--- a/pom.xml
+++ b/pom.xml
@@ -127,6 +127,20 @@
       <version>5.2.0</version>
     </dependency>
 
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>2.10.0</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>java-hamcrest</artifactId>
+      <version>2.0.0.0</version>
+      <scope>test</scope>
+    </dependency>
+
     <!-- future used: add JUnit test
     <dependency>
       <groupId>org.apache.maven.plugin-testing</groupId>

--- a/src/main/java/org/pitest/maven/PmpMojo.java
+++ b/src/main/java/org/pitest/maven/PmpMojo.java
@@ -2,7 +2,9 @@ package org.pitest.maven;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Predicate;
 
 import org.apache.maven.artifact.Artifact;
@@ -35,6 +37,12 @@ public class PmpMojo extends AbstractPitMojo
 
     @Parameter(property = "skippedModules")
     protected ArrayList<String> skippedModules;
+
+    /** If specified, modules before this module will be skipped. */
+    @Parameter(property = "continueFromModule")
+    protected String continueFromModule;
+
+    private static Set<String> alreadyVisitedModules = new HashSet<>();
 
     // if true: do not execute PIT, only display information about shouldRun or not
     @Parameter(defaultValue = "false", property = "shouldDisplayOnly")
@@ -121,6 +129,25 @@ public class PmpMojo extends AbstractPitMojo
 
         return(result);
     }
+
+    public void setContinueFromModule(String continueFromModule) {
+      this.continueFromModule = continueFromModule;
+    }
+
+    public String getContinueFromModule() {
+      return continueFromModule;
+    }
+
+    public boolean isContinueFromModuleSatisfied(MavenProject module) {
+      if (continueFromModule == null) {
+        // property is not specified
+        return true;
+      }
+
+      // note that the current module has already been added
+      return alreadyVisitedModules.contains(continueFromModule);
+    }
+
 
     // **********************************************************************
     // ******** associations
@@ -223,6 +250,7 @@ public class PmpMojo extends AbstractPitMojo
         RunDecision theDecision;
         PmpProject myPmpProject;
         String projectName = getProject().getArtifactId();
+        alreadyVisitedModules.add(projectName);
         // if no targetModules are specified, take all modules
         boolean isTargetModule = (getTargetModules() == null ||
             getTargetModules().isEmpty() || isInTargetModules(projectName));
@@ -255,6 +283,11 @@ public class PmpMojo extends AbstractPitMojo
         {
             message = projectName + " is a skipped module";
             theDecision.addReason(message);
+        }
+
+        if (!isContinueFromModuleSatisfied(getProject())) {
+          message = projectName + " is before " + continueFromModule + " from which the execution shall be continued";
+          theDecision.addReason(message);
         }
 
         if (shouldDisplayOnly())


### PR DESCRIPTION
If an analysis aborts due to an error, it is not possible to continue the execution from a given module because the use of Maven's -rf parameter causes an error (leads to no mutations found). Hence, it would be necessary to reanalyze the whole project.
The introduced parameter `continueFromModule` allows to start the execution from the specified module.