### PR TITLE
Skip modules without tests

### DIFF
--- a/src/main/java/org/pitest/maven/PmpMojo.java
+++ b/src/main/java/org/pitest/maven/PmpMojo.java
@@ -256,6 +256,11 @@ public class PmpMojo extends AbstractPitMojo
             message = projectName + " is a skipped module";
             theDecision.addReason(message);
         }
+        
+        if (targetTests.isEmpty()) {
+            message = projectName + " contains no tests";
+            theDecision.addReason(message);
+        }
 
         if (shouldDisplayOnly())
         {


### PR DESCRIPTION
If no test classes are found, the property target tests will be empty. As a consequence, PIT will derive patterns to match test classes from the packages in the application code. This may include undesired tests from other modules (and can cause ClassNotFoundExceptions). With this fix, modules without test classes will be skipped.